### PR TITLE
Add access to xhr object

### DIFF
--- a/lib/assets/javascripts/opal/jquery/http.rb
+++ b/lib/assets/javascripts/opal/jquery/http.rb
@@ -48,8 +48,8 @@ class HTTP
         http.body = data;
         http.xhr = xhr;
 
-        if (typeof(str) === 'object') {
-          http.json = #{ JSON.from_object `str` };
+        if (typeof(data) === 'object') {
+          http.json = #{ JSON.from_object `data` };
         }
 
         return #{ http.succeed };


### PR DESCRIPTION
This PR adds access to the ajax XHR object and a helper method to get a specific response header:

``` ruby
HTTP.get("/some/url") do |response|
  if response.ok?
    alert response.get_header('x-header-name')
  end
end
```

I needed this functionality for header based API pagination.
