### PR TITLE
Add native mapping for Element#empty

### DIFF
--- a/opal/opal-jquery/element.rb
+++ b/opal/opal-jquery/element.rb
@@ -66,7 +66,7 @@ class Element
   expose :hide, :show, :toggle, :children, :blur, :closest, :data
   expose :focus, :find, :next, :siblings, :text, :trigger, :append
   expose :height, :width, :serialize, :is, :filter, :last, :first
-  expose :wrap, :stop, :clone
+  expose :wrap, :stop, :clone, :empty
 
   # We alias some jquery methods to common ruby method names.
   alias succ next


### PR DESCRIPTION
Seems it went missing after method_missing was removed.
