### PR TITLE
Let Element#to_s behave the same as Element#inspect

### DIFF
--- a/opal/opal-jquery/element.rb
+++ b/opal/opal-jquery/element.rb
@@ -264,7 +264,19 @@ class Element < `dom_class`
     }
   end
 
-  alias to_s inspect
+  def to_s
+    %x{
+      var val, el, result = [];
+
+      for (var i = 0, length = self.length; i < length; i++) {
+        el  = self[i];
+
+        result.push(el.outerHTML)
+      }
+
+      return result.join(', ');
+    }
+  end
 
   def length
     `self.length`

--- a/spec/element/to_s_spec.rb
+++ b/spec/element/to_s_spec.rb
@@ -2,13 +2,13 @@ require "spec_helper"
 
 describe "Element#to_s" do
   html <<-HTML
-    <div id="foo"></div>
+    <div id="foo">hi</div>
     <div class="bar"></div>
     <p id="lol" class="bar"></div>
   HTML
 
   it "returns a string representation of the elements" do
-    Element.find('#foo').to_s.should == '#<Element [<div id="foo">]>'
-    Element.find('.bar').to_s.should == '#<Element [<div class="bar">, <p id="lol" class="bar">]>'
+    Element.find('#foo').to_s.should == '<div id="foo">hi</div>'
+    Element.find('.bar').to_s.should == '<div class="bar"></div>, <p id="lol" class="bar"></p>'
   end
 end


### PR DESCRIPTION
This was discovered by doing

``` ruby
puts element
p element
```

which gave different results

```
#<Element:undefined>
#<Element [<input id="some_id" class="some_class">]> 
```
