### PR TITLE
Make height/width not return null, be set with = methods instead of jquery calls.

### DIFF
--- a/opal/opal-jquery/element.rb
+++ b/opal/opal-jquery/element.rb
@@ -63,7 +63,7 @@ class Element < `dom_class`
   expose :after, :before, :parent, :parents, :prepend, :prev, :remove
   expose :hide, :show, :toggle, :children, :blur, :closest, :detach
   expose :focus, :find, :next, :siblings, :text, :trigger, :append
-  expose :height, :width, :serialize, :is, :filter, :last, :first
+  expose :serialize, :is, :filter, :last, :first
   expose :wrap, :stop, :clone, :empty
   expose :get, :attr, :prop
 
@@ -90,6 +90,8 @@ class Element < `dom_class`
   alias_native :slide_up, :slideUp
   alias_native :slide_toggle, :slideToggle
   alias_native :fade_toggle, :fadeToggle
+  alias_native :height=, :height
+  alias_native :width=, :width
 
   def to_n
     self
@@ -326,5 +328,13 @@ class Element < `dom_class`
 
   def value
     `self.val() || ""`
+  end
+
+  def height
+    `self.height() || nil`
+  end
+
+  def width
+    `self.width() || nil`
   end
 end

--- a/spec/element/height_width_spec.rb
+++ b/spec/element/height_width_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe "Element height and width" do
+  html <<-HTML
+    <div id="dimensions" style='width: 100px; height: 200px'></div>
+  HTML
+
+  describe '#height' do
+    it "should grab height of existing element" do
+      elm = Element.id('dimensions')
+
+      expect(elm.height).to eq(200)
+    end
+
+    it "should return nil if item does not exist" do
+      elm = Element.find('#not-an-elm')
+
+      expect(elm.height).to eq(nil)
+    end
+  end
+
+  describe '#height=' do
+    it "should allow us to set height" do
+      elm = Element.id('dimensions')
+      elm.height = 121
+
+      expect(elm.height).to eq(121)
+    end
+  end
+
+  describe '#width' do
+    it "should grab width of existing element" do
+      elm = Element.id('dimensions')
+
+      expect(elm.width).to eq(100)
+    end
+
+    it "should return nil if item does not exist" do
+      elm = Element.find('#not-an-elm')
+
+      expect(elm.width).to eq(nil)
+    end
+  end
+
+  describe '#width=' do
+    it "should allow us to set width" do
+      elm = Element.id('dimensions')
+      elm.width = 121
+
+      expect(elm.width).to eq(121)
+    end
+  end
+end


### PR DESCRIPTION
calling width on bad result set returns null which ruby cannot deal with
