### PR TITLE
proposed fix for #61 and #61 - Document.ready

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,3 @@
-opal/**/*.rb
 --markup markdown
 -
 CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -298,6 +298,23 @@ request.errback { |response|
 }
 ```
 
+### Supplying an XHR method
+
+To supply an XHR callback include a lambda with the `xhr` option:
+
+```ruby
+update_progress = lambda do
+  xhr = `new window.XMLHttpRequest()`
+  update_progress = lambda do |evt|
+    # update your progress here
+  end
+  `xhr.upload.addEventListener("progress", update_progress, false)`
+  xhr
+end
+
+cloud_xfer = HTTP.put "http://my.cloud.storage/location", xhr: update_progress, ... etc ...
+```
+
 ##  License
 
 (The MIT License)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ Document.ready? do
 end
 ```
 
+Document.ready (without the question mark) returns the equivilent promise. 
+Like other promises it can be combined using the when and then methods.
+
+```ruby
+Document.ready.then do |ready|
+  puts "Page is ready to use!"
+end
+```
+
 The `Kernel#alert` method is shown above too.
 
 ### Event handling

--- a/lib/opal/jquery/document.rb
+++ b/lib/opal/jquery/document.rb
@@ -11,13 +11,21 @@ module Browser
   #
   # A useful method on {Document} is the {#ready?} method, which can be used to
   # run a block once the document is ready. This is equivalent to passing a
-  # function to the `jQuery` constructor.
+  # function to the `jQuery` constructor.  Unlike jQuery it will work correctly 
+  # even if called *after* the document is already loaded.
   #
   #     Document.ready? do
   #       puts "Page is ready to use!"
   #     end
   #
   # Just like jQuery, multiple blocks may be passed to {#ready?}.
+  #
+  # Document.ready (without the question mark) returns the equivilent promise. 
+  # Like other promises it can be combined using the when and then methods.
+  #
+  #     Document.ready.then do |ready|
+  #       puts "Page is ready to use!"
+  #     end
   #
   # ### Document head and body elements
   #
@@ -45,6 +53,7 @@ module Browser
     `var $ = #{JQUERY_SELECTOR.to_n}` # cache $ for SPEED
 
     # Register a block to run once the document/page is ready.
+    # will call the block if the document is already ready
     #
     # @example
     #   Document.ready? do
@@ -52,8 +61,25 @@ module Browser
     #   end
     #
     def ready?(&block)
-      `$(#{block})` if block_given?
+      @@__isReady ? block.call : `$(#{block})` if block_given?
     end
+    
+    # Return a promise that resolves when the document is ready.
+    #
+    # @example
+    #   Document.ready.then do |r|
+    #     puts "ready to go"
+    #   end
+    #
+    def ready
+      promise = Promise.new
+      Document.ready? { promise.resolve }
+      promise
+    end
+    
+    module_function :ready?
+    
+    ready? { @@__isReady = true }
 
     # Returns document title.
     #

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -11,7 +11,7 @@ describe Document do
   
   describe "ready" do
     async "resolves when document is ready" do
-      Document.ready.then do |response|
+      Document.ready.then do 
         async { Document.ready.resolved?.should be_truthy }
       end
     end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -8,7 +8,15 @@ describe Document do
       Document.ready? { }
     end
   end
-
+  
+  describe "ready" do
+    async "resolves when document is ready" do
+      Document.ready.then do |response|
+        async { Document.ready.resolved?.should be_truthy }
+      end
+    end
+  end
+  
   describe "title" do
     it "gets the document title" do
       Document.title.should be_kind_of(String)


### PR DESCRIPTION
Document.ready returns a promise.  Did not want to modify behavior of .ready? so as not to create any breaking changes, but perhaps to be consistent with HTTP.get that is what should happen.

Document.ready? now checks to make sure the Document is not already loaded.  It does not use $.isReady since this is not available in Zepto, but instead creates a variable to track this.  

Added test for the Document.ready promise

Updated Docs