### PR TITLE
Add missing event key modifiers

### DIFF
--- a/lib/opal/jquery/event.rb
+++ b/lib/opal/jquery/event.rb
@@ -175,6 +175,18 @@ class Event
     `#@native.ctrlKey`
   end
 
+  def meta_key
+    `#@native.metaKey`
+  end
+
+  def alt_key
+    `#@native.altKey`
+  end
+
+  def shift_key
+    `#@native.shiftKey`
+  end
+
   def key_code
     `#@native.keyCode`
   end


### PR DESCRIPTION
We already had `ctrl_key`, but modifiers for Alt, Shift, and Meta were missing.

There weren't any tests for `Event#ctrl_key` and I'm not sure if it's possible to trigger the event with those flags set, so I didn't add any for these methods, either. If I'm mistaken, I'll go ahead and knock them out.