### PR TITLE
Support and run specs against opal-rspec 0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.gem
 Gemfile.lock
+/gemfiles/*.lock
 build
 gh-pages
 /.bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,6 @@ matrix:
   allow_failures:
     - rvm: 2.1.4
 
+gemfile:
+  - Gemfile
+  - gemfiles/rspec.0.5.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ script: rake $RUN
 matrix:
   include:
     - rvm: 2.2
+      Gemfile: Gemfile
+    - rvm: 2.2
+      Gemfile: gemfiles/rspec.0.5.gemfile
     - rvm: 2.1
     - rvm: 1.9.3
     - rvm: 2.0
@@ -18,7 +21,3 @@ matrix:
 
   allow_failures:
     - rvm: 2.1.4
-
-gemfile:
-  - Gemfile
-  - gemfiles/rspec.0.5.gemfile

--- a/gemfiles/rspec.0.5.gemfile
+++ b/gemfiles/rspec.0.5.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path:'../'
+
+gem 'opal-rspec', '0.5.0.beta2'

--- a/opal-jquery.gemspec
+++ b/opal-jquery.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths  = ['lib']
 
   s.add_runtime_dependency 'opal', '>= 0.7.0', '< 0.9.0'
-  s.add_development_dependency 'opal-rspec', '~> 0.4.0'
+  s.add_development_dependency 'opal-rspec', '~> 0.4'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Same concept as https://github.com/opal/opal-rails/pull/67

Will build correctly once opal-rspec 0.5.0.beta2 is pushed to Rubygems
