### PR TITLE
Make HTTP#get_header return nil if header is not set in response

### DIFF
--- a/lib/opal/jquery/http.rb
+++ b/lib/opal/jquery/http.rb
@@ -223,8 +223,12 @@ class HTTP
   #
   # @param key [String] name of the header to get
   # @return [String] value of the header
+  # @return [nil] if the header +key+ was not in the response
   def get_header(key)
-    `#@xhr.getResponseHeader(#{key});`
+    %x{
+      var value = #@xhr.getResponseHeader(#{key});
+      return (value === null) ? nil : value;
+    }
   end
 
   private

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -78,4 +78,18 @@ describe HTTP do
       end
     end
   end
+
+  describe '#get_header' do
+    async 'returns the header value' do
+      HTTP.get(good_url) do |response|
+        async { expect(response.get_header 'Content-Type').to eq 'text/plain' }
+      end
+    end
+
+    async 'returns nil' do
+      HTTP.get(good_url) do |response|
+        async { expect(response.get_header 'Does-Not-Exist').to be nil }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Before this change, if the header is not set in the response, it will be JavaScript `null`. Now it returns Opals `nil` instead.

Also added specs for `HTTP#get_header`.