### PR TITLE
Alias native jQuery 'click'

### DIFF
--- a/lib/opal/jquery/element.rb
+++ b/lib/opal/jquery/element.rb
@@ -338,6 +338,9 @@ class Element < `#{JQUERY_CLASS.to_n}`
   # @!method submit()
   alias_native :submit
 
+  # @!method click()
+  alias_native :click
+
   # @!method text=(text)
   #
   # Set text content of each element in this collection.


### PR DESCRIPTION
Shouldn't there be a spec or something to make sure there are no more missing method mappings?
