### PR TITLE
Add setting to prevent payload automatic processing

### DIFF
--- a/lib/opal/jquery/http.rb
+++ b/lib/opal/jquery/http.rb
@@ -161,14 +161,14 @@ class HTTP
 
     @settings.update options
 
-    settings, payload = @settings.to_n, @payload
+    settings, payload = @settings.to_n, @payload.to_n
 
     %x{
-      if (typeof(#{payload}) === 'string') {
+      if (typeof(payload) === 'string' || settings.processData === false) {
         settings.data = payload;
       }
       else if (payload != nil) {
-        settings.data = payload.$to_json();
+        settings.data = JSON.stringify(payload);
         settings.contentType = 'application/json';
       }
 


### PR DESCRIPTION
I was trying to send a multipart payload, but since the current code is processing everything that is not a string as json, I couldn't make through. This PR uses the flag `processData` for the same purpose that is used in [jquery ajax](https://api.jquery.com/jQuery.ajax/). 
In my case, I use it together with `contentType: false` to send a FormData:
```ruby
payload = Native(%x{new FormData(#{form.get(0)})})
options = {payload: payload, contentType: false, processData: false}
HTTP.post url, options do |response|
...
end

``` 