### PR TITLE
Add Element#replace_all & Element#replace_with

### DIFF
--- a/lib/opal/jquery/element.rb
+++ b/lib/opal/jquery/element.rb
@@ -337,6 +337,12 @@ class Element < `#{JQUERY_CLASS.to_n}`
   # @!method remove_class(class_name)
   alias_native :remove_class, :removeClass
 
+  # @!method replace_all(target)
+  alias_native :replace_all, :replaceAll
+
+  # @!method replace_with(new_content)
+  alias_native :replace_with, :replaceWith
+
   # @!method submit()
   alias_native :submit
 


### PR DESCRIPTION
Hi, 

While developing [glimmer-dsl-opal](https://github.com/AndyObtiva/glimmer-dsl-opal), I noticed that opal-jquery was missing [Element#replace_all](https://api.jquery.com/replaceAll/) and [Element#replace_with](https://api.jquery.com/replaceWith/) from jQuery, so I added them.

If you need me to do anything else to have them accepted, such as writing tests, please let me know.

Andy Maleh