### PR TITLE
Event location property

### DIFF
--- a/lib/opal/jquery/event.rb
+++ b/lib/opal/jquery/event.rb
@@ -171,6 +171,10 @@ class Event
     `#@native.originalEvent.touches[0].pageY`
   end
 
+  def location
+    `#@native.originalEvent.location`
+  end
+
   def ctrl_key
     `#@native.ctrlKey`
   end


### PR DESCRIPTION
Contributing Event#location property mentioned in https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location

It enables knowing whether the user pressed the right or the left shift button for example.