### PR TITLE
Remove untaint method for Ruby 3.2 compatibility

### DIFF
--- a/lib/opal/jquery.rb
+++ b/lib/opal/jquery.rb
@@ -9,5 +9,5 @@ else
   require 'opal'
   require 'opal/jquery/version'
 
-  Opal.append_path File.expand_path('../..', __FILE__).untaint
+  Opal.append_path File.expand_path('../..', __FILE__)
 end


### PR DESCRIPTION
Hi, the gem wouldn't work after installing it. 

It has the method `untaint` that has been removed in Ruby 3.2, therefore I have removed it to make it work.

More info : 
Why : https://bugs.ruby-lang.org/issues/16131
Commit : https://github.com/ruby/ruby/commit/9b7a7e9cef2daa3aec4aeb55205aab9da2db4eb6